### PR TITLE
ndt.go: send at least one MSG_RESULT back

### DIFF
--- a/nettests/ndt/ndt.go
+++ b/nettests/ndt/ndt.go
@@ -556,7 +556,20 @@ func handle_connection(cc net.Conn) {
 		}
 	}
 
-	// FIXME: send MSG_RESULTS to client
+	// Send MSG_RESULTS to the client
+
+	/*
+	 * TODO: Here we should actually send results but to do that we need
+	 * first to implement reading Web100 variables from /proc/web100.
+	 *
+	 * Until we reach this point, send back a variable that NDT client
+	 * will ignore but that is consistent with what it would expect.
+	 */
+	err = write_standard_message(cc, writer, kv_msg_results,
+		"botticelli_does_not_yet_collect_web100_data_sorry: 1\n")
+	if err != nil {
+		return
+	}
 
 	// Send empty MSG_LOGOUT to client
 


### PR DESCRIPTION
The [specification](https://github.com/ndt-project/ndt/wiki/NDTProtocol) doesn't explicitly state that the server MUST send to the client at least one MSG_RESULT message. But, looking into the sequence diagram that is part of the specification, this is CLEARLY implied.

As such, botticelli was broken because it was violating the protocol.

The proper fix would be to read Web100 variables, compute a number of metrics and send those back to the client. But, botticelli has not reached this point of maturity yet.

As a fix, I implemented sending back a single variable formatted as the NDT code would expect, so that it does not crash, but named using a clearly nonstandard name such that it's not used.

Bug reported by @nkinkade, thanks!